### PR TITLE
BLD: pin pydm for entrypoint support, python for NEP 29

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 89cd5abe968a2a81705c9996bbea40ebd34191c3ce3ea65551af37d7f84658a4
 
 build:
-  number: 0
+  number: 1
   noarch: python
   entry_points:
     - typhos = typhos.cli:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,17 +17,17 @@ build:
 
 requirements:
   host:
-    - python >=3.7
+    - python >=3.8
     - pip
   run:
-    - python >=3.7
+    - python >=3.8
     - coloredlogs
     - entrypoints
     - numpy
     - numpydoc
     - ophyd >=1.5.0
     - pcdsutils
-    - pydm
+    - pydm >=1.16.0
     - pyqt >=5
     - pyqtgraph
     - qdarkstyle


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
This is a follow-up to #24 in which I experienced merger's regret. This package now needs a minimum pydm version to run properly and is no longer supporting python 3.7 as per NEP 29.